### PR TITLE
Fixes #33 plus two things.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ Makefile
 /config.guess
 /config.status
 /config.log
-/config.h.in
 /config.sub
 /configure
 /config.h

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,82 @@
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the <fnmatch.h> header file. */
+#undef HAVE_FNMATCH_H
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
+
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the `strcasecmp' function. */
+#undef HAVE_STRCASECMP
+
+/* Define to 1 if you have the `strchr' function. */
+#undef HAVE_STRCHR
+
+/* Define to 1 if you have the `strdup' function. */
+#undef HAVE_STRDUP
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if you have the `strtol' function. */
+#undef HAVE_STRTOL
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* Name of package */
+#undef PACKAGE
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* Version number of package */
+#undef VERSION
+
+/* Define to empty if `const' does not conform to ANSI C. */
+#undef const
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+#undef inline
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+#undef size_t

--- a/src/gpp.c
+++ b/src/gpp.c
@@ -21,7 +21,7 @@
 
 /* To compile under MS VC++, one must define WIN_NT */
 #if HAVE_CONFIG_H
-# include <config.h>
+# include "config.h"
 #endif
 
 #ifdef WIN_NT              /* WIN NT settings */
@@ -1875,7 +1875,7 @@ int DoArithmEval(char *buf, int pos1, int pos2, int *result) {
     if (SpliceInfix(buf, pos1, pos2, "=~", &spl1, &spl2)) {
 #if ! HAVE_FNMATCH_H
         bug("globbing support has not been compiled in");
-#endif
+#else
         if (!DoArithmEval(buf, pos1, spl1, &result1)
                 || !DoArithmEval(buf, spl2, pos2, &result2)) {
             char *str1, *str2;
@@ -1894,6 +1894,7 @@ int DoArithmEval(char *buf, int pos1, int pos2, int *result) {
             free(str2);
         } else
             *result = (result1 == result2);
+#endif
         return 1;
     }
 


### PR DESCRIPTION
Fixes #33.  And...

Even with `! HAVE_FNMATCH_H` there is a reference to `fnmatch`.  The reference causes a link error when building under stock Visual Studio 2017.  This update fixes the problem.

Quotes are used to include files (config.h) from the same directory as the source file (gpp.c).  This update changes the include for config.h to reflect the fact that the include file is expected to be in the same directory.
