### PR TITLE
Fix for "the defined(...) macro is already defined" warning being issued in case of nested #eval statements

### DIFF
--- a/src/gpp.c
+++ b/src/gpp.c
@@ -2083,9 +2083,11 @@ char *ArithmEval(int pos1, int pos2) {
 
     /* first define the defined(...) operator */
     i = findIdent("defined", strlen("defined"));
-    if (i >= 0)
-        warning("the defined(...) macro is already defined");
-    else {
+    if (i >= 0) {
+        /* either nested evals or macro redefinition by the user */
+        if (macros[i].nnamedargs != -2)
+            warning("the defined(...) macro is already defined");
+    } else {
         newmacro("defined", strlen("defined"), 1);
         macros[nmacros].macrolen = 0;
         macros[nmacros].macrotext = malloc(1);


### PR DESCRIPTION
I don't have a code sample ready, but something like this should trigger the warning before the fix:
```
#define Num1 #eval 5*5
5*5*5 = #eval Num1*5
```